### PR TITLE
Fix pandas 2.0 incompatibility and parameterize load_biome_herarchy_dict

### DIFF
--- a/trapiche/utils.py
+++ b/trapiche/utils.py
@@ -258,14 +258,27 @@ def tax_annotations_from_file(f):
 # --- ---
 
 
-@lru_cache
-def load_biome_herarchy_dict():
-    """Load amended biome hierarchy mapping from HF assets (cached)."""
-    from .config import TaxonomyToVectorParams as _T2V
-    from .utils import _get_hf_model_path
 
-    _p = _T2V()
-    p = _get_hf_model_path(_p.hf_model, _p.model_version, "biome_herarchy_amended_*.json")
+# Use a default sentinel to maintain backward compatibility while allowing explicit overrides.
+@lru_cache
+def load_biome_herarchy_dict(model_name: str | None = None, model_version: str | None = None):
+    """Load amended biome hierarchy mapping from HF assets (cached).
+
+    Args:
+        model_name: HF repository id. Defaults to TaxonomyToVectorParams.hf_model.
+        model_version: Model version. Defaults to TaxonomyToVectorParams.model_version.
+
+    Returns:
+        tuple: (biome_herarchy_dct, biome_herarchy_dct_reversed)
+    """
+    if model_name is None or model_version is None:
+        from .config import TaxonomyToVectorParams as _T2V
+
+        _p = _T2V()
+        model_name = model_name or _p.hf_model
+        model_version = model_version or _p.model_version
+
+    p = _get_hf_model_path(model_name, model_version, "biome_herarchy_amended_*.json")
 
     if not p.exists():
         raise FileNotFoundError(f"{p} not found")
@@ -440,7 +453,7 @@ def split_tt(df, frac, rs, lin):
     """
     test_samples = []
     if frac != 0:  # skip this step if models are trained with the full dataset
-        if type(lin) == str:
+        if isinstance(lin, str):  
             depth = len(lin.split(":"))
             tdf = df[df.max_depth > depth]
             tdf["d3"] = [":".join(x.split(":")[: depth + 1]) for x in tdf.lineage]
@@ -454,7 +467,9 @@ def split_tt(df, frac, rs, lin):
                 test_samples.extend(gr.sample(frac=frac, random_state=rs).SAMPLE_ID.values)
             else:
                 accum = 0
-                for ix, n in gr.project.value_counts().sample(frac=1, random_state=rs).iteritems():
+                for ix, n in (
+                    gr.project.value_counts().sample(frac=1, random_state=rs).items()
+                ):
                     momo = tdf[tdf.project == ix].SAMPLE_ID
                     test_samples.extend(momo)
                     accum += momo.shape[0]
@@ -462,7 +477,7 @@ def split_tt(df, frac, rs, lin):
                         break
     test_ixes = df[df.SAMPLE_ID.isin(test_samples)].index
     df["IS_TEST"] = [False] * df.shape[0]
-    df.loc[test_ixes, ("IS_TEST")] = True
+    df.loc[test_ixes, "IS_TEST"] = True  
 
 
 def three_split(df, random_state=None, frac_=0.2):
@@ -545,7 +560,7 @@ def i_T(term, graph):
 
     If term is a string, use its ancestors; if iterable, use the set itself.
     """
-    if type(term) == str:
+    if isinstance(term, str):  
         veT = nx.ancestors(graph, term) | {term}
     else:
         veT = term


### PR DESCRIPTION
This PR fixes two issues in utils.py.

1. Fix pandas 2.0 incompatibility

Problem:
`Series.iteritems() `was removed in pandas 2.0, causing an AttributeError.

Fix:
Replaced `Series.iteritems()` with `Series.items()` in `split_tt()`.

Additional improvement:
Replaced `type(lin) == str` with `isinstance(lin, str)` in `split_tt() `and `i_T()`.


2. Parameterize `load_biome_herarchy_dict()
`
Problem:
`load_biome_herarchy_dict()` always resolved the biome hierarchy file through
TaxonomyToVectorParams even when called from other components.

Because the function used an LRU cache, the resolved path was shared across
callers regardless of the pipeline.

Fix:
Added optional parameters:

`model_name`
`model_version`

These allow callers to explicitly specify the model repository while keeping
backward-compatible defaults.

resolved issue: #7 #9 