### PR TITLE
KNN output type mismatch in full_stack_prediction

### DIFF
--- a/trapiche/taxonomy_prediction.py
+++ b/trapiche/taxonomy_prediction.py
@@ -388,6 +388,39 @@ def knn_batch(
     return results
 
 
+def _knn_records_to_prediction(
+    records: list[dict[str, Any]] | None,
+) -> dict[str, float] | None:
+    """Convert KNN result records into the ``{biome: score}`` dict expected downstream.
+
+    ``knn_batch`` returns, per query, either ``None`` or a list of dicts with
+    keys ``BIOME`` and ``COSINE_SIMILARITY``.  The rest of the pipeline
+    (``full_stack_prediction``) expects ``dict[str, float]`` mapping a biome
+    lineage string to a confidence score.
+
+    The transformation picks the biome with the highest mean cosine similarity
+    across all returned neighbours and returns it as a single-entry dict.
+    """
+    if not records:
+        return None
+
+    # Aggregate cosine similarities per biome
+    biome_scores: dict[str, list[float]] = defaultdict(list)
+    for rec in records:
+        biome = rec.get("BIOME")
+        sim = rec.get("COSINE_SIMILARITY", 0.0)
+        if biome is not None:
+            biome_scores[biome].append(float(sim))
+
+    if not biome_scores:
+        return None
+
+    # Pick the biome with the highest mean similarity
+    best_biome = max(biome_scores, key=lambda b: sum(biome_scores[b]) / len(biome_scores[b]))
+    best_score = sum(biome_scores[best_biome]) / len(biome_scores[best_biome])
+    return {best_biome: best_score}
+
+
 np.seterr(divide="ignore", invalid="ignore")  # handle bad files == divition by zero error
 
 
@@ -457,9 +490,10 @@ def full_stack_prediction(
     # string_pattern = "Digestive system"
     # knn refinement unconstrained
     prediction_keys = [list(d.keys()) if d is not None else None for d in top_predictions]
-    refined_predictions = knn_batch(
+    refined_predictions_raw = knn_batch(
         predictions=prediction_keys, query_vectors=query_vector, params=params
     )
+    refined_predictions = [_knn_records_to_prediction(rp) for rp in refined_predictions_raw]
     # refined_predictions = [
     #     crp if crp is None or re.search(string_pattern, list(crp.keys())[0], re.I) else None
     #     for crp in refined_predictions
@@ -469,9 +503,12 @@ def full_stack_prediction(
     constrained_prediction_keys = [
         list(d.keys()) if d is not None else None for d in constrained_top_predictions
     ]
-    constrained_refined_predictions = knn_batch(
+    constrained_refined_predictions_raw = knn_batch(
         predictions=constrained_prediction_keys, query_vectors=query_vector, params=params
     )
+    constrained_refined_predictions = [
+        _knn_records_to_prediction(crp) for crp in constrained_refined_predictions_raw
+    ]
     # Set to None those refined predictions that do not match the string_pattern. predictions are List[Optional[Dict[str, float]]]
     # constrained_refined_predictions = [
     #     crp if crp is None or re.search(string_pattern, list(crp.keys())[0], re.I) else None


### PR DESCRIPTION
<p>Adds a transformation layer between <code>knn_batch()</code> and <code>full_stack_prediction()</code> to resolve a structural type mismatch that causes <code>TypeError: unhashable type: 'dict'</code> when KNN refinement is enabled (<code>KNN_VALUE_DEFAULT &gt; 0</code>).</p>
<hr>
<h2>Problem</h2>
<p><code>knn_batch()</code> returns:</p>
<pre><code class="language-python">list[list[dict[str, Any]] | None]
</code></pre>
<p>where each non-<code>None</code> element is a list of record dicts:</p>
<pre><code class="language-python">[
    {"ACCESSION": "...", "COSINE_SIMILARITY": 0.9, "BIOME": "root:Environmental:..."},
    {"ACCESSION": "...", "COSINE_SIMILARITY": 0.85, "BIOME": "root:Environmental:..."},
]
</code></pre>
<p>However, <code>full_stack_prediction()</code> consumes the KNN results as if they were:</p>
<pre><code class="language-python">dict[str, float]  # {biome_lineage_string: score}
</code></pre>
<p>This is the same format used by the deep learning predictions (<code>unambig_pred</code>, <code>unambig_constr_pred</code>, etc.). The mismatch surfaces at two points:</p>
<p><strong>1. Heuristic selection :</strong></p>
<pre><code class="language-python">best_heuristic_gold = biome_herarchy_dct_reversed.get(
    list(best_heuristic)[0] if best_heuristic is not None else None,
    None,
)
</code></pre>
<p>When <code>best_heuristic</code> is a <code>list[dict]</code>, <code>list(best_heuristic)[0]</code> returns a <strong>dict</strong>, not a string. Using a dict as a dict key raises <code>TypeError: unhashable type: 'dict'</code>.</p>
<p><strong>2. Score extraction :</strong></p>
<pre><code class="language-python">best_heuristic_gold = {best_heuristic_gold: best_heuristic[list(best_heuristic)[0]]}
</code></pre>
<p>Indexing a list with a dict raises <code>TypeError</code>.</p>
<p><strong>3. <code>normalize_to_ontology</code> :</strong></p>
<pre><code class="language-python">normalize_to_ontology(best_heuristic, target_ontology="AMENDED")
</code></pre>
<p>Calls <code>.items()</code> on the prediction — fails on <code>list[dict]</code>.</p>
<h3>Why this is currently hidden</h3>
<p><code>KNN_VALUE_DEFAULT</code> is set to <code>-1</code>, which causes <code>knn_batch()</code> to early-return <code>[None] * len(predictions)</code>. The bug is only triggered when KNN is re-enabled, which the codebase's own TODO indicates is intended:</p>
<pre><code class="language-python">KNN_VALUE_DEFAULT = -1  # THE FUNCTION IS DEPRECATED. TODO: Transform function to KNN tool
</code></pre>
<hr>
<h2>Solution</h2>
<h3>New bridge function: <code>_knn_records_to_prediction()</code></h3>
<p>Converts the raw KNN record list into the <code>{biome: score}</code> dict that all downstream code expects:</p>
<pre><code class="language-python">def _knn_records_to_prediction(
    records: list[dict[str, Any]] | None,
) -&gt; dict[str, float] | None:
</code></pre>
<p><strong>Logic:</strong></p>
<ol>
<li>Groups all returned KNN neighbours by their <code>BIOME</code> value</li>
<li>Computes the <strong>mean cosine similarity</strong> per biome across all neighbours</li>
<li>Returns a single-entry dict <code>{best_biome: mean_score}</code> for the biome with the highest mean similarity</li>
<li>Returns <code>None</code> if input is <code>None</code> or empty</li>
</ol>
<p>This matches the single-entry dict pattern used by the unambiguous prediction paths:</p>
<pre><code class="language-python"># Existing pattern in the codebase:
top_dominant = {top_dominant_term: _top_pred.get(top_dominant_term, 0)}
</code></pre>
<h3>Transformation applied at both KNN call sites</h3>
<pre><code class="language-python"># Before (unconstrained)
refined_predictions = knn_batch(...)

# After (unconstrained)
refined_predictions_raw = knn_batch(...)
refined_predictions = [_knn_records_to_prediction(rp) for rp in refined_predictions_raw]

# Before (constrained)
constrained_refined_predictions = knn_batch(...)

# After (constrained)
constrained_refined_predictions_raw = knn_batch(...)
constrained_refined_predictions = [
    _knn_records_to_prediction(crp) for crp in constrained_refined_predictions_raw
]
</code></pre>
<hr>
<h2>Files Changed</h2>

File | Change
-- | --
trapiche/taxonomy_prediction.py | Added _knn_records_to_prediction() bridge function; applied transformation at both KNN call sites in full_stack_prediction()


<hr>
<h2>Heuristic Priority (unchanged)</h2>
<p>The fix preserves the intended priority ordering documented in the code:</p>
<ol>
<li><code>refined_constrained_prediction</code> (KNN + text constraints)</li>
<li><code>unambig_constr_pred</code> (deep model + text constraints)</li>
<li><code>refined_prediction</code> (KNN unconstrained)</li>
<li><code>unambig_pred</code> (deep model unconstrained)</li>
<li><code>None</code></li>
</ol>
<hr>
